### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/code/docvqa/wandb/run-20250516_102012-reb6b992/files/requirements.txt
+++ b/code/docvqa/wandb/run-20250516_102012-reb6b992/files/requirements.txt
@@ -139,7 +139,7 @@ protobuf==6.30.2
 psutil==7.0.0
 pure_eval==0.2.3
 pyarrow==20.0.0
-pyautogen==0.9
+ag2==0.9
 pycparser==2.22
 pydantic==2.11.3
 pydantic_core==2.33.1

--- a/code/docvqa/wandb/run-20250516_103322-w7wbk1zl/files/requirements.txt
+++ b/code/docvqa/wandb/run-20250516_103322-w7wbk1zl/files/requirements.txt
@@ -139,7 +139,7 @@ protobuf==6.30.2
 psutil==7.0.0
 pure_eval==0.2.3
 pyarrow==20.0.0
-pyautogen==0.9
+ag2==0.9
 pycparser==2.22
 pydantic==2.11.3
 pydantic_core==2.33.1

--- a/code/mp_docvqa/wandb/run-20250516_105717-ycqj0p59/files/requirements.txt
+++ b/code/mp_docvqa/wandb/run-20250516_105717-ycqj0p59/files/requirements.txt
@@ -139,7 +139,7 @@ protobuf==6.30.2
 psutil==7.0.0
 pure_eval==0.2.3
 pyarrow==20.0.0
-pyautogen==0.9
+ag2==0.9
 pycparser==2.22
 pydantic==2.11.3
 pydantic_core==2.33.1

--- a/code/mp_docvqa/wandb/run-20250516_110940-ihxn6g7j/files/requirements.txt
+++ b/code/mp_docvqa/wandb/run-20250516_110940-ihxn6g7j/files/requirements.txt
@@ -139,7 +139,7 @@ protobuf==6.30.2
 psutil==7.0.0
 pure_eval==0.2.3
 pyarrow==20.0.0
-pyautogen==0.9
+ag2==0.9
 pycparser==2.22
 pydantic==2.11.3
 pydantic_core==2.33.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
